### PR TITLE
fixed module name issue & add java sources to jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /*.launch
 /*.dic
 /*.mvn/
+*.iml
 
 **/TempTest.java
 /.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
 	<build>
 		<resources>
 			<resource>
+				<directory>src/main/java</directory>
+				<includes>
+					<include>**/*.java</include>
+				</includes>
+			</resource>
+			<resource>
 				<directory>src/main/resources</directory>
 			</resource>
 			<resource>
@@ -145,7 +151,7 @@
 				<groupId>net.ltgt.gwt.maven</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>
 				<configuration>
-					<moduleName>org.jresearch.threetenbp.gwt.module</moduleName>
+					<moduleName>org.jresearch.threetenbp.gwt.threetenbpGwt</moduleName>
 					<moduleShortName>threetenbpGwt</moduleShortName>
 					<relocateSuperSource>true</relocateSuperSource>
 					<relocateTestSuperSource>true</relocateTestSuperSource>
@@ -153,6 +159,12 @@
 						<testArg>-testMethodTimeout</testArg>
 						<testArg>30</testArg>
 					</testArgs>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<configuration>
+					<skipSource>true</skipSource>
 				</configuration>
 			</plugin>
 			<!-- Setup testing -->

--- a/src/test/java/org/jresearch/threetenbp/gwt/client/AbstractTest.java
+++ b/src/test/java/org/jresearch/threetenbp/gwt/client/AbstractTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractTest extends GWTTestCase {
 
 	@Override
 	public String getModuleName() {
-		return "org.jresearch.threetenbp.gwt.module";
+		return "org.jresearch.threetenbp.gwt.threetenbpGwt";
 	}
 
 	@Override

--- a/src/test/java/org/jresearch/threetenbp/gwt/client/GwtSupportTest.java
+++ b/src/test/java/org/jresearch/threetenbp/gwt/client/GwtSupportTest.java
@@ -13,7 +13,7 @@ public class GwtSupportTest extends GWTTestCase {
 	 */
 	@Override
 	public String getModuleName() {
-		return "org.jresearch.threetenbp.gwt.module";
+		return "org.jresearch.threetenbp.gwt.threetenbpGwt";
 	}
 
 	@Test

--- a/src/test/java/org/jresearch/threetenbp/gwt/client/GwtTest.java
+++ b/src/test/java/org/jresearch/threetenbp/gwt/client/GwtTest.java
@@ -17,7 +17,7 @@ public class GwtTest extends GWTTestCase {
 	 */
 	@Override
 	public String getModuleName() {
-		return "org.jresearch.threetenbp.gwt.module";
+		return "org.jresearch.threetenbp.gwt.threetenbpGwt";
 	}
 
 	@Test


### PR DESCRIPTION
- fixed issue that the module name is `org.jresearch.threetenbp.gwt.module` instead of `org.jresearch.threetenbp.gwt.threetenbpGwt`

- avoid generating source jar

- add source files to jar


